### PR TITLE
Add FSharpPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of awesome F# frameworks, libraries, software and resources.
 
 ## Contents
  * [Actor frameworks](#actor-frameworks)
+ * [General purpose libraries](#general-purpose-libraries)
  * [Build tools](#build-tools)
  * [Compilers](#compilers)
  * [Data Science](#data-science)
@@ -33,6 +34,9 @@ A curated list of awesome F# frameworks, libraries, software and resources.
  * [Hopac](http://hopac.github.io/Hopac/Hopac.html) - concurrent ML style concurrent programming library for F#. [MIT]
  * [FSharpx.Async](https://github.com/fsprojects/FSharpx.Async) - collection of asynchronous programming utilities for F# [Apache 2.0]
  * [FSharp.Control.AsyncSeq](https://github.com/fsprojects/FSharp.Control.AsyncSeq) - collection of asynchronous programming utilities for F# [Apache 2.0]
+ 
+## General purpose libraries
+ * [FSharpPlus](https://github.com/gmpl/FSharpPlus) - extensions for F#. [Apache 2.0]
 
 ## Build tools
  * [FAKE](http://fsharp.github.io/FAKE/) - "F# Make" is a cross platform build automation system. [Apache 2.0]


### PR DESCRIPTION
Add link to https://github.com/gmpl/FSharpPlus and put it under newly created "general purpose libraries" section.